### PR TITLE
manually retrive Error due to out-of-tree module

### DIFF
--- a/src/s2n_quic.rs
+++ b/src/s2n_quic.rs
@@ -161,7 +161,8 @@ where
         self.conn.close(
             code.value()
                 .try_into()
-                .unwrap_or_else(|_| VarInt::MAX.into()),
+                // unwrap because this is safe
+                .unwrap_or_else(|_| s2n_quic::application::Error::new(VarInt::MAX.into()).unwrap()),
         );
     }
 }
@@ -435,9 +436,10 @@ where
     }
 
     fn reset(&mut self, reset_code: u64) {
-        let _ = self
-            .stream
-            .reset(reset_code.try_into().unwrap_or_else(|_| VarInt::MAX.into()));
+        let _ =
+            self.stream.reset(reset_code.try_into().unwrap_or_else(|_| {
+                s2n_quic::application::Error::new(VarInt::MAX.into()).unwrap()
+            }));
     }
 
     fn send_id(&self) -> StreamId {


### PR DESCRIPTION
Because this module is out-of-tree, Rust for some reason refuses to acknowledge that `Error: From<VarInt>` is satisfied. This does not occur when the module is in-tree. Simply including the trait definitions from s2n-quic doesn't work either. This patch provides a fix which allows s2n-quic-h3 to still compile out-of-tree; it does not need to be forwarded back into s2n-quic, as the issue does not exist in-tree.

Signed-off-by: Amy Parker <amy@amyip.net>